### PR TITLE
Filter contributor list to match # on /profile page

### DIFF
--- a/app/containers/HomePage/index.js
+++ b/app/containers/HomePage/index.js
@@ -174,10 +174,15 @@ export class HomePage extends React.PureComponent { // eslint-disable-line react
     });
 
     axios.post(newGraphQLRoot, {
-      query: '{publications { edges { node { authors } } }}',
+      query: '{publications (authors:"~", distinct: true) { edges { node { authors } } }}',
     }).then((response) => {
       const contributors = new Set();
-      response.data.data.publications.edges.map((edge) => JSON.parse(edge.node.authors).map((author) => contributors.add(author)));
+      response.data.data.publications.edges
+        .map((edge) => JSON.parse(edge.node.authors)
+        .filter((x) => x !== 'others')
+        .filter((x) => x !== 'catapp')
+        .filter((x) => x !== 'Catapp')
+        .map((author) => contributors.add(author)));
       this.setState({
         contributors: contributors.size,
       });


### PR DESCRIPTION
Before this patch the homepage shows 132 contributors and 128 on the /profile page which seems a bit murky. Filtering some entries get us to 129 which is still off by one but can't that last one right now.