### PR TITLE
Show additional calc info and improve loading speed

### DIFF
--- a/app/components/About/index.js
+++ b/app/components/About/index.js
@@ -47,17 +47,18 @@ class About extends React.Component { // eslint-disable-line react/prefer-statel
 
         <Paper className={this.props.classes.paper}>
           <h2>License</h2>
-          <img src={ccLogoBig} alt="ccLogoBig" />
           <div className={this.props.classes.text}>
             Except where otherwise noted, content on Catalysis-Hub is licensed under a
             {' '}
             <a rel="license" href="http://creativecommons.org/licenses/by/4.0/">Creative Commons Attribution 4.0 International License</a>
 .
           </div>
+          <img src={ccLogoBig} alt="ccLogoBig" />
         </Paper>
 
         <Paper className={this.props.classes.paper}>
-          <h2>People</h2>
+          <h2>People and Contact</h2>
+          <div>The platform is developed at the SUNCAT Center for Interface Science and Catalysis, SLAC National Accelerator Laboratory, Stanford University. Contact information for the primary people involved is provided below. For technical support please contact postdoc Kirsten Winther at winther@stanford.edu.</div>
           <ul className={this.props.classes.peopleList}>
             {Object.keys(people).map((name, i) => (
               <li key={`person_${i}`}>

--- a/app/components/Apps/filteredApps.js
+++ b/app/components/Apps/filteredApps.js
@@ -44,9 +44,17 @@ class FilteredApps extends React.Component { // eslint-disable-line react/prefer
                     elevation={0}
                   >
                     <Tooltip title={app.tooltip} placement="top">
-                      <h3>
-                        {getAppIcon(app.title)}
-                        {'\u00A0'}{app.title}</h3>
+                      {(app.title === 'Activity Maps' || app.title === 'Scaling Relations' || app.title === 'Pourbaix Diagrams') ?
+                        <h3>
+                          {getAppIcon(app.title)}
+                          {'\u00A0'}{app.title}{' (Beta) '}
+                        </h3>
+                        :
+                        <h3>
+                          {getAppIcon(app.title)}
+                          {'\u00A0'}{app.title}
+                        </h3>
+                      }
                     </Tooltip>
                     <div className={this.props.classes.appHint}>{app.tooltip} <MdChevronRight /></div>
                   </Paper>

--- a/app/components/SingleStructureView/index.js
+++ b/app/components/SingleStructureView/index.js
@@ -17,6 +17,7 @@ import {
 } from 'utils/functions';
 
 import GeometryCanvasWithOptions from 'components/GeometryCanvasWithOptions';
+import GraphQlbutton from 'components/GraphQlbutton';
 
 const initialState = {
   Formula: '',
@@ -39,10 +40,31 @@ class SingleStructureView extends React.Component { // eslint-disable-line react
   constructor(props) {
     super(props);
     this.state = initialState;
+    this.state.printquery = `query{systems( uniqueId: "${this.props.selectedSystem.aseId}" ) {
+  edges {
+    node {
+      Formula
+      energy
+      numbers
+      initialMagmoms
+      magmoms
+      magmom
+      charges
+      momenta
+      calculator
+      keyValuePairs
+      calculatorParameters
+      publication {
+        title
+        authors
+        doi
+      }
+    }
+  }
+}}`;
   }
   render() {
     const energy = this.props.selectedSystem.energy || this.state.energy || 0.0;
-
     let x;
     let y;
     let z;
@@ -72,11 +94,11 @@ class SingleStructureView extends React.Component { // eslint-disable-line react
           <ul style={{ width: '50%' }}>
             <li>Formula: {this.props.selectedSystem.Formula}</li>
             <li>DFT Total Energy: {energy.toFixed(2)} eV</li>
+            {this.props.selectedSystem.energyCorrection !== 0 &&
+              <li> Energy correction: {this.props.selectedSystem.energyCorrection}</li>
+            }
             <li>DFT Code: {this.props.selectedSystem.DFTCode}</li>
             <li>DFT Functional: {this.props.selectedSystem.DFTFunctional}</li>
-            {_.isEmpty(this.props.selectedSystem.calculatorParameters) ? null :
-            <li> DFT parameters: {this.props.selectedSystem.calculatorParameters}</li>
-            }
             <li>Publication: {prettyPrintReference(this.props.selectedPublication)}</li>
             <div>
               {_.isEmpty(this.props.selectedPublication.doi) ? null :
@@ -97,6 +119,9 @@ class SingleStructureView extends React.Component { // eslint-disable-line react
             <li> <a href={`/publications/${this.props.selectedPublication.pubId}`}>
                 View all reactions in dataset
                 </a>
+            </li>
+            <li>
+               Open <GraphQlbutton query={this.state.printquery} newSchema /> to view calculational details.
             </li>
           </ul>
         </div>

--- a/app/containers/EnergiesPage/Input.js
+++ b/app/containers/EnergiesPage/Input.js
@@ -274,7 +274,7 @@ class EnergiesPageInput extends React.Component { // eslint-disable-line react/p
           <div> A quick guide: </div>
           <ul>
             <li> Leave fields blank if you {"don't"} want to impose any restrictions. </li>
-            <li> For the <b>Reactants</b> and <b>Product</b> fields, choose the chemical species taking part in the left- and/or right hand side of the chemical reaction respectively. The phase of the molecules and elements can also be specified, such that {"'CO2gas'"} refers to CO<sub>2</sub> in the gas phase, whereas {"'CO2*'"} refers to CO<sub>2</sub> adsorbed on the surface. </li>
+            <li> For the <b>Reactants</b> and <b>Products</b> fields, choose the chemical species taking part in the left- and/or right hand side of the chemical reaction respectively. The phase of the molecules and elements can also be specified, such that {"'CO2gas'"} refers to CO<sub>2</sub> in the gas phase, whereas {"'CO2*'"} refers to CO<sub>2</sub> adsorbed on the surface. </li>
             <li> In the <b>Surface</b> field, enter the (reduced) chemical composition of the surface, or a sum of elements that must be present, such as {"'Ag+'"} or {"'Ag+Sr'"}. </li>
           </ul>
         </div>

--- a/app/containers/EnergiesPage/Input.js
+++ b/app/containers/EnergiesPage/Input.js
@@ -191,6 +191,7 @@ class EnergiesPageInput extends React.Component { // eslint-disable-line react/p
         chemicalComposition
         reactionSystems {
           name
+          energyCorrection
           aseId
         }
       }

--- a/app/containers/EnergiesPage/MatchingReactions.js
+++ b/app/containers/EnergiesPage/MatchingReactions.js
@@ -129,13 +129,15 @@ class MatchingReactions extends React.Component { // eslint-disable-line react/p
       loading: true,
     });
     this.props.saveLoading(true);
-    let catappIds;
-    let catappNames;
+    let cathubIds;
+    let cathubNames;
+    let catenergyCorrections;
     if (typeof reaction.reactionSystems !== 'undefined' && reaction.reactionSystems !== null) {
-      catappIds = (reaction.reactionSystems.map((x) => x.aseId));
-      catappNames = (reaction.reactionSystems.map((x) => x.name));
+      cathubIds = (reaction.reactionSystems.map((x) => x.aseId));
+      cathubNames = (reaction.reactionSystems.map((x) => x.name));
+      catenergyCorrections = (reaction.reactionSystems.map((x) => x.energyCorrection));
     } else {
-      catappIds = {};
+      cathubIds = {};
       snackbarActions.open('Scroll down for detailed structure.');
     }
 
@@ -160,9 +162,10 @@ class MatchingReactions extends React.Component { // eslint-disable-line react/p
     });
 
     this.props.clearSystems();
-    catappIds.map((key, index) => {
+    cathubIds.map((key, index) => {
       let aseId = key;
-      const name = catappNames[index];
+      const name = cathubNames[index];
+      const energyCorrection = catenergyCorrections[index];
       if (typeof aseId === 'object') {
         aseId = aseId[1];
       }
@@ -189,6 +192,7 @@ class MatchingReactions extends React.Component { // eslint-disable-line react/p
         node.Facet = reaction.facet;
         node.publication = this.props.publication;
         node.aseId = aseId;
+        node.energyCorrection = energyCorrection;
         node.key = name;
         node.full_key = node.Formula;
         const ads = name.replace('star', ' @');

--- a/app/containers/HomePage/index.js
+++ b/app/containers/HomePage/index.js
@@ -125,53 +125,35 @@ export class HomePage extends React.PureComponent { // eslint-disable-line react
             }, 2000
           );
         });
-        axios.post(newGraphQLRoot, {
-          query: `{systems(order:"mtime", last: 1) {
+      }
+    });
+    axios.post(newGraphQLRoot, {
+      query: `{publications(stime: 0, op: ">", order: "stime", last: 1) {
+  totalCount
   edges {
     node {
-     Mtime
-     publication {
-       pubId
-     }
+      pubId
+      Stime
+      title
+      authors
+      journal
+      pages
+      volume
+      year
+      doi
     }
   }
 }}`,
-        }).then((lpidResponse) => {
-          const lastPubId = _.get(lpidResponse, 'data.data.systems.edges[0].node.publication[0].pubId');
-          const lastPublicationTime = _.get(lpidResponse, 'data.data.systems.edges[0].node.Mtime');
-          const pubTimeArray = lastPublicationTime.split(' ');
-          pubTimeArray.splice(3, 1, ',');
-          this.setState({
-            lastPublicationTime: pubTimeArray.join(' ').replace(' ,', ''),
-          });
-          axios.post(newGraphQLRoot, {
-            query: `{publications(pubId:"${lastPubId}") {
-  edges {
-    node { title authors journal pages volume year doi pubId }
-  }
-}}`,
-          }).then((lpResponse) => {
-            this.setState({
-              lastPublication: _.get(lpResponse, 'data.data.publications.edges[0].node'),
-            });
-          });
-        });
-      }
+    }).then((lpidResponse) => {
+      const lastPublicationTime = _.get(lpidResponse, 'data.data.publications.edges[0].node.Stime');
+      const pubTimeArray = lastPublicationTime.split(' ');
+      pubTimeArray.splice(3, 1, ',');
+      this.setState({
+        lastPublicationTime: pubTimeArray.join(' ').replace(' ,', ''),
+        lastPublication: _.get(lpidResponse, 'data.data.publications.edges[0].node'),
+        publications: _.get(lpidResponse, 'data.data.publications.totalCount'),
+      });
     });
-    axios.post(newGraphQLRoot, { query: '{publications(first: 0) { totalCount edges { node { id } } }}' }).then((response) => {
-      if (response.data.data.reactions === null) {
-        this.setState({
-          loading: false,
-          error: true,
-        });
-      } else {
-        this.setState({
-          loading: false,
-          publications: response.data.data.publications.totalCount,
-        });
-      }
-    });
-
     axios.post(newGraphQLRoot, {
       query: '{publications (authors:"~", distinct: true) { edges { node { authors } } }}',
     }).then((response) => {

--- a/app/utils/constants.js
+++ b/app/utils/constants.js
@@ -102,8 +102,6 @@ module.exports = {
       'http://suncat.stanford.edu/people/kirsten-winther'],
     'Max Hoffmann': ['Software Engineer. Former postdoc, SLAC National Accelerator Laboratory',
       'http://suncat.stanford.edu/people/max-hoffmann'],
-    'Jens N\u00F8rskov': ['Villum Kann Rasmussen Professor, Technical University of Denmark',
-      'http://www.staff.dtu.dk/jkno'],
     'Jacob Boes': ['Postdoc, SLAC National Accelerator Laboratory',
       'http://suncat.stanford.edu/people/jacob-russell-boes'],
     'Osman Mamun': ['Postdoc, SLAC National Accelerator Laboratory',

--- a/app/utils/functions.js
+++ b/app/utils/functions.js
@@ -86,10 +86,11 @@ export const prettyPrintReference = (ref) =>
         {restoreSC(author)}
       </Link>
     )).reduce((prev, curr) => [prev, '; ', curr]))}. </span> : null }
-    {(ref.journal !== '' && typeof ref.journal !== 'undefined' && ref.journal !== null) ? <i>{ref.journal}, </i> : null }
-    {(ref.volume !== '' && typeof ref.volume !== 'undefined' && ref.volume !== null) ? <span>{ref.volume} </span> : null}
-    {(ref.year !== '' && typeof ref.year !== 'undefined' && ref.year !== null) ? <span>({ref.year}). </span> : null}
-    {(ref.pages !== '' && typeof ref.pages !== 'undefined' && ref.pages !== null) ? <span>{ref.pages}. </span> : null}
+    {(ref.journal !== '' && typeof ref.journal !== 'undefined' && ref.journal !== null) ? <i>{ref.journal}. </i> : null }
+    {(ref.volume !== '' && typeof ref.volume !== 'undefined' && ref.volume !== null) ? <b>{ref.volume}</b> : null}
+    {(ref.number !== '' && typeof ref.number !== 'undefined' && ref.number !== null) ? <span>{ref.number}</span> : null}
+    {(ref.pages !== '' && typeof ref.pages !== 'undefined' && ref.pages !== null) ? <span>{', '}{ref.pages} </span> : null}
+    {(ref.year !== '' && typeof ref.year !== 'undefined' && ref.year !== null) ? <span>({ref.year})</span> : null}
   </span>);
 
 


### PR DESCRIPTION
Several small improvements to the homepage:
* Show energycorrections for structures in reaction search
* Show link to graphql-query for each structure in reaction search
* Display all publication info, including volume and number
* improve loading speed of front page and publication page, by using a submission time ordering directly from publication table
* Add "Beta" label to aps that are work in progress